### PR TITLE
feat: implementa paginación para el endpoint de catálogo

### DIFF
--- a/src/grape_kun_api/settings.py
+++ b/src/grape_kun_api/settings.py
@@ -73,6 +73,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'grape_kun_api.wsgi.application'
 
+# Cosas de Rest
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10
+}
 
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases

--- a/src/mangas/views.py
+++ b/src/mangas/views.py
@@ -9,7 +9,7 @@ from manga_scrap.proveedores.mangaList import MangaList
 import json
 
 class MangaPreviewView(ListAPIView):
-    queryset = MangaPreview.objects
+    queryset = MangaPreview.objects.all()
     serializer_class = MangaPreviewSerializer
 
 class MangaDetalleView(APIView):


### PR DESCRIPTION
Implementa paginación para el endpoint de catálogo. Por defecto el estilo de paginación ocupará el número de página como parámetro de la URL y mostrará hasta 10 previews por página.